### PR TITLE
Add summarize feature

### DIFF
--- a/fenix/app/build.gradle
+++ b/fenix/app/build.gradle
@@ -481,6 +481,8 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 
 dependencies {
     implementation project(':browser-engine-gecko')
+    implementation "com.aallam.openai:openai-client:3.2.0"
+    implementation("io.ktor:ktor-client-android:2.2.4")
 
     implementation FenixDependencies.kotlin_coroutines
     implementation FenixDependencies.kotlin_coroutines_android

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
@@ -347,6 +347,18 @@ class DefaultBrowserToolbarMenuController(
                 )
             }
 
+            is ToolbarMenu.Item.Summarize -> browserAnimator.captureEngineViewAndDrawStatically {
+                settings.installPwaOpened = true
+                MainScope().launch {
+                    with(activity.components.useCases.webAppUseCases) {
+                            val directions =
+                                BrowserFragmentDirections.actionBrowserFragmentToSummarizeFragment()
+                            navController.navigateSafe(R.id.browserFragment, directions)
+
+                    }
+                }
+            }
+
             is ToolbarMenu.Item.Downloads -> browserAnimator.captureEngineViewAndDrawStatically {
                 navController.nav(
                     R.id.browserFragment,
@@ -459,6 +471,8 @@ class DefaultBrowserToolbarMenuController(
                 Events.browserMenuAction.record(Events.BrowserMenuActionExtra("set_default_browser"))
             is ToolbarMenu.Item.RemoveFromTopSites ->
                 Events.browserMenuAction.record(Events.BrowserMenuActionExtra("remove_from_top_sites"))
+            is ToolbarMenu.Item.Summarize ->
+                Events.browserMenuAction.record(Events.BrowserMenuActionExtra("summarize"))
         }
     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -342,6 +342,14 @@ open class DefaultToolbarMenu(
         handleBookmarkItemTapped()
     }
 
+    val summarizeItem = BrowserMenuImageText(
+        context.getString(R.string.library_summarize),
+        R.drawable.ic_readermode,
+        primaryTextColor(),
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.Summarize)
+    }
+
     private val deleteDataOnQuit = BrowserMenuImageText(
         label = context.getString(R.string.delete_browsing_data_on_quit_action),
         imageResource = R.drawable.mozac_ic_quit,
@@ -376,6 +384,7 @@ open class DefaultToolbarMenu(
                 customizeReaderView.apply { visible = ::shouldShowReaderViewCustomization },
                 openInApp.apply { visible = ::shouldShowOpenInApp },
                 reportSiteIssuePlaceholder,
+                summarizeItem,
                 BrowserMenuDivider(),
                 addToHomeScreenItem.apply { visible = ::canAddToHomescreen },
                 installToHomescreen.apply { visible = ::canInstall },

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenu.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenu.kt
@@ -35,6 +35,7 @@ interface ToolbarMenu {
         object History : Item()
         object Downloads : Item()
         object NewTab : Item()
+        object Summarize : Item()
     }
 
     val menuBuilder: BrowserMenuBuilder

--- a/fenix/app/src/main/java/org/mozilla/fenix/summarize/SummarizeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/summarize/SummarizeFragment.kt
@@ -1,0 +1,63 @@
+package org.mozilla.fenix.summarize
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.asLiveData
+import mozilla.components.browser.state.selector.selectedTab
+import org.mozilla.fenix.R
+import org.mozilla.fenix.databinding.FragmentSummarizeBinding
+import org.mozilla.fenix.ext.requireComponents
+
+class SummarizeFragment : DialogFragment() {
+
+    private var _binding: FragmentSummarizeBinding? = null
+    private val binding get() = _binding!!
+
+    private var summary: String = ""
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(STYLE_NO_TITLE, R.style.CreateShortcutDialogStyle)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentSummarizeBinding.inflate(inflater, container, false)
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.doneButton.setOnClickListener { dismiss() }
+
+
+        requireComponents.core.store.state.selectedTab?.content?.let { tabContent ->
+
+            binding.dialogTitle.text = tabContent.title
+
+            SummarizeUtil.getSummaryForUrl(tabContent.url).asLiveData()
+                .observe(viewLifecycleOwner) { sum ->
+                    summary += sum
+                    binding.summaryTextView.text = summary
+                }
+        }
+
+
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+
+    }
+
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/summarize/SummarizeUtil.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/summarize/SummarizeUtil.kt
@@ -7,7 +7,7 @@ import com.aallam.openai.client.OpenAI
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.mapNotNull
 
-private const val OPENAI_API_KEY = "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"
+private const val OPENAI_API_KEY = "API_KEY_HERE"
 private const val OPENAI_API_MODEL = "gpt-3.5-turbo"
 
 class SummarizeUtil {

--- a/fenix/app/src/main/java/org/mozilla/fenix/summarize/SummarizeUtil.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/summarize/SummarizeUtil.kt
@@ -1,0 +1,36 @@
+package org.mozilla.fenix.summarize
+
+import com.aallam.openai.api.BetaOpenAI
+import com.aallam.openai.api.chat.*
+import com.aallam.openai.api.model.ModelId
+import com.aallam.openai.client.OpenAI
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapNotNull
+
+private const val OPENAI_API_KEY = "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"
+private const val OPENAI_API_MODEL = "gpt-3.5-turbo"
+
+class SummarizeUtil {
+    companion object {
+        @OptIn(BetaOpenAI::class)
+        fun getSummaryForUrl(url: String): Flow<String> {
+            val openAI = OpenAI(token = OPENAI_API_KEY)
+
+            val chatCompletionRequest = ChatCompletionRequest(
+                model = ModelId(OPENAI_API_MODEL),
+                messages = listOf(
+                    ChatMessage(
+                        role = ChatRole.User,
+                        content = "Summarize $url",
+                    ),
+                ),
+            )
+
+            return openAI.chatCompletions(chatCompletionRequest).mapNotNull {
+                it.choices[0].delta?.content
+            }
+        }
+    }
+
+
+}

--- a/fenix/app/src/main/res/layout/fragment_summarize.xml
+++ b/fenix/app/src/main/res/layout/fragment_summarize.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/summarizeWrapper"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?scrim"
+    android:fitsSystemWindows="true"
+    tools:context="org.mozilla.fenix.summarize.SummarizeFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="32dp"
+        android:layout_marginBottom="16dp"
+        android:background="@drawable/dialog_background"
+        android:paddingTop="16dp"
+        app:layout_constrainedHeight="true"
+        android:paddingBottom="16dp">
+
+        <TextView
+            android:id="@+id/dialog_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:text="@string/library_summarize"
+            android:textAppearance="@style/HeaderTextStyle"
+            android:textSize="@dimen/summarize_header_text_size"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/text_scrollview"
+            />
+
+
+        <ScrollView
+            android:id="@+id/text_scrollview"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fillViewport="true"
+            android:minHeight="@dimen/summarize_scroll_view_min_height"
+            app:layout_constraintBottom_toTopOf="@id/done_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/dialog_title"
+            app:layout_constrainedHeight="true"
+            >
+
+            <TextView
+                android:id="@+id/summary_text_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="10dp"
+                android:textAlignment="center"
+                android:textSize="16sp" />
+
+        </ScrollView>
+
+
+        <Button
+            android:id="@+id/done_button"
+            style="@style/CreateShortcutDialogButton"
+            android:layout_marginEnd="16dp"
+            android:layout_marginTop="26dp"
+            android:background="?selectableItemBackground"
+            android:text="@string/summarize_done_button"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/text_scrollview" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</FrameLayout>

--- a/fenix/app/src/main/res/layout/fragment_summarize.xml
+++ b/fenix/app/src/main/res/layout/fragment_summarize.xml
@@ -24,9 +24,11 @@
 
         <TextView
             android:id="@+id/dialog_title"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
+            android:paddingStart="@dimen/summarize_text_padding"
+            android:paddingEnd="@dimen/summarize_text_padding"
             android:text="@string/library_summarize"
             android:textAppearance="@style/HeaderTextStyle"
             android:textSize="@dimen/summarize_header_text_size"
@@ -55,9 +57,9 @@
                 android:id="@+id/summary_text_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:padding="10dp"
+                android:padding="@dimen/summarize_text_padding"
                 android:textAlignment="center"
-                android:textSize="16sp" />
+                android:textSize="@dimen/summarize_summary_text_size" />
 
         </ScrollView>
 
@@ -65,8 +67,8 @@
         <Button
             android:id="@+id/done_button"
             style="@style/CreateShortcutDialogButton"
-            android:layout_marginEnd="16dp"
-            android:layout_marginTop="26dp"
+            android:layout_marginEnd="@dimen/summarize_done_button_margin"
+            android:layout_marginTop="@dimen/summarize_done_button_margin"
             android:background="?selectableItemBackground"
             android:text="@string/summarize_done_button"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/fenix/app/src/main/res/navigation/nav_graph.xml
+++ b/fenix/app/src/main/res/navigation/nav_graph.xml
@@ -262,6 +262,9 @@
             android:id="@+id/action_browserFragment_to_createShortcutFragment"
             app:destination="@id/createShortcutFragment" />
         <action
+            android:id="@+id/action_browserFragment_to_summarizeFragment"
+            app:destination="@id/summarizeFragment" />
+        <action
             android:id="@+id/action_browserFragment_to_pwaOnboardingDialogFragment"
             app:destination="@id/pwaOnboardingDialogFragment" />
         <action
@@ -934,6 +937,11 @@
         android:id="@+id/createShortcutFragment"
         android:name="org.mozilla.fenix.shortcut.CreateShortcutFragment"
         tools:layout="@layout/fragment_create_shortcut" />
+
+    <dialog
+        android:id="@+id/summarizeFragment"
+        android:name="org.mozilla.fenix.summarize.SummarizeFragment"
+        tools:layout="@layout/fragment_summarize" />
     <dialog
         android:id="@+id/pwaOnboardingDialogFragment"
         android:name="org.mozilla.fenix.shortcut.PwaOnboardingDialogFragment"

--- a/fenix/app/src/main/res/values/dimens.xml
+++ b/fenix/app/src/main/res/values/dimens.xml
@@ -193,7 +193,7 @@
 
     <!-- Summarize -->
     <dimen name="summarize_header_text_size">24sp</dimen>
-    <dimen name="summarize_summary_text_size">16sp</dimen>
+    <dimen name="summarize_summary_text_size">18sp</dimen>
     <dimen name="summarize_scroll_view_min_height">300dp</dimen>
     <dimen name="summarize_text_padding">8dp</dimen>
     <dimen name="summarize_done_button_margin">16dp</dimen>

--- a/fenix/app/src/main/res/values/dimens.xml
+++ b/fenix/app/src/main/res/values/dimens.xml
@@ -190,4 +190,8 @@
     <dimen name="accessibility_min_height">48dp</dimen>
 
     <dimen name="tap_increase_16">16dp</dimen>
+
+    <!-- Summarize -->
+    <dimen name="summarize_header_text_size">24sp</dimen>
+    <dimen name="summarize_scroll_view_min_height">300dp</dimen>
 </resources>

--- a/fenix/app/src/main/res/values/dimens.xml
+++ b/fenix/app/src/main/res/values/dimens.xml
@@ -193,5 +193,8 @@
 
     <!-- Summarize -->
     <dimen name="summarize_header_text_size">24sp</dimen>
+    <dimen name="summarize_summary_text_size">16sp</dimen>
     <dimen name="summarize_scroll_view_min_height">300dp</dimen>
+    <dimen name="summarize_text_padding">8dp</dimen>
+    <dimen name="summarize_done_button_margin">16dp</dimen>
 </resources>

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -2046,5 +2046,4 @@
     <!--Summarize Strings -->
     <!-- String for done button for summarize -->
     <string name="summarize_done_button">Done</string>
-    <string name="title_feature_summarize">Module Title</string>
 </resources>

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<resources xmlns:tools="http://schemas.android.com/tools"  xmlns:moz="http://mozac.org/tools">
+<resources xmlns:moz="http://mozac.org/tools" xmlns:tools="http://schemas.android.com/tools">
     <!-- App name for private browsing mode. The first parameter is the name of the app defined in app_name (for example: Fenix)-->
     <string name="app_name_private_5">Private %s</string>
     <!-- App name for private browsing mode. The first parameter is the name of the app defined in app_name (for example: Fenix)-->
@@ -403,7 +403,7 @@
     <!-- Long text for a detail explanation indicating what will happen if cookie banner handling is off for a site, this is shown as part of the cookie banner panel in the toolbar. The first parameter is the application name -->
     <string name="reduce_cookie_banner_details_panel_description_off_for_site">%1$s will clear this site’s cookies and refresh the page. Clearing all cookies may sign you out or empty shopping carts.</string>
     <!-- Long text for a detail explanation indicating what will happen if cookie banner handling is on for a site, this is shown as part of the cookie banner panel in the toolbar. The first parameter are the application name -->
-    <string name="reduce_cookie_banner_details_panel_description_on_for_site_1"  moz:RemovedIn="111" tools:ignore="UnusedResources">%1$s can try to automatically reject cookie requests.</string>
+    <string name="reduce_cookie_banner_details_panel_description_on_for_site_1" moz:RemovedIn="111" tools:ignore="UnusedResources">%1$s can try to automatically reject cookie requests.</string>
     <!-- Long text for a detail explanation indicating what will happen if cookie banner handling is on for a site, this is shown as part of the cookie banner panel in the toolbar. The first parameter is the application name -->
     <string name="reduce_cookie_banner_details_panel_description_on_for_site_2">%1$s tries to automatically reject all cookie requests on supported sites.</string>
     <!-- Title text for the dialog use on the control branch of the experiment to determine which context users engaged the most -->
@@ -713,6 +713,8 @@
     <!-- Library -->
     <!-- Option in Library to open Downloads page -->
     <string name="library_downloads">Downloads</string>
+    <!-- Option in Library to open summarize current page -->
+    <string name="library_summarize">Summary</string>
     <!-- Option in library to open Bookmarks page -->
     <string name="library_bookmarks">Bookmarks</string>
     <!-- Option in library to open Desktop Bookmarks root page -->
@@ -894,10 +896,10 @@
     <string name="collection_open_tabs">Open tabs</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Collection name</string>
-	<!-- Text for the menu button to rename a top site -->
-	<string name="rename_top_site">Rename</string>
-	<!-- Text for the menu button to remove a top site -->
-	<string name="remove_top_site">Remove</string>
+    <!-- Text for the menu button to rename a top site -->
+    <string name="rename_top_site">Rename</string>
+    <!-- Text for the menu button to remove a top site -->
+    <string name="remove_top_site">Remove</string>
     <!-- Text for the menu button to delete a top site from history -->
     <string name="delete_from_history">Delete from history</string>
     <!-- Postfix for private WebApp titles, placeholder is replaced with app name -->
@@ -1175,7 +1177,7 @@
     <string name="toast_copy_link_to_clipboard">Copied to clipboard</string>
     <!-- An option from the share dialog to sign into sync -->
     <string name="sync_sign_in">Sign in to Sync</string>
-     <!-- An option from the three dot menu to sync and save data -->
+    <!-- An option from the three dot menu to sync and save data -->
     <string name="sync_menu_sync_and_save_data">Sync and save data</string>
     <!-- An option from the share dialog to send link to all other sync devices -->
     <string name="sync_send_to_all">Send to all devices</string>
@@ -1950,14 +1952,14 @@
     <string name="top_sites_max_limit_confirmation_button">OK, Got It</string>
     <!-- Label for the preference to show the shortcuts for the most visited top sites on the homepage -->
     <string name="top_sites_toggle_top_recent_sites_4">Shortcuts</string>
-	<!-- Title text displayed in the rename top site dialog. -->
-	<string name="top_sites_rename_dialog_title">Name</string>
+    <!-- Title text displayed in the rename top site dialog. -->
+    <string name="top_sites_rename_dialog_title">Name</string>
     <!-- Hint for renaming title of a shortcut -->
     <string name="shortcut_name_hint">Shortcut name</string>
-	<!-- Button caption to confirm the renaming of the top site. -->
-	<string name="top_sites_rename_dialog_ok">OK</string>
-	<!-- Dialog button text for canceling the rename top site prompt. -->
-	<string name="top_sites_rename_dialog_cancel">Cancel</string>
+    <!-- Button caption to confirm the renaming of the top site. -->
+    <string name="top_sites_rename_dialog_ok">OK</string>
+    <!-- Dialog button text for canceling the rename top site prompt. -->
+    <string name="top_sites_rename_dialog_cancel">Cancel</string>
     <!-- Text for the menu button to open the homepage settings. -->
     <string name="top_sites_menu_settings">Settings</string>
     <!-- Text for the menu button to navigate to sponsors and privacy support articles. '&amp;' is replaced with the ampersand symbol: & -->
@@ -2040,4 +2042,9 @@
     <string name="a11y_action_label_read_article">read the article</string>
     <!-- Action label for links to the Firefox Pocket website. Talkback will append this to say "Double tap to open link to learn more". -->
     <string name="a11y_action_label_pocket_learn_more">open link to learn more</string>
+
+    <!--Summarize Strings -->
+    <!-- String for done button for summarize -->
+    <string name="summarize_done_button">Done</string>
+    <string name="title_feature_summarize">Module Title</string>
 </resources>


### PR DESCRIPTION
Take home for @html5cat

### Before running 
Got to `SummarizeUtil` and assign an openAI API key to `OPENAI_API_KEY`

### Demo
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/23137381/230667152-4836df7a-9b48-45f4-87ea-cdece2a95ddf.gif)

### Testing
Ideally, I would've added unit, scenario and layout tests but due to time constraints due to being on call at my current was not able to add them

